### PR TITLE
Fix InterrubtedException issue

### DIFF
--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyHostnameVerifier.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyHostnameVerifier.kt
@@ -54,7 +54,8 @@ internal class CertificateTransparencyHostnameVerifier(
     logListService,
     logListDataSource,
     policy,
-    diskCache
+    diskCache,
+    logger
 ) {
 
     override fun verify(host: String, sslSession: SSLSession): Boolean {

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyInterceptor.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyInterceptor.kt
@@ -55,7 +55,8 @@ internal class CertificateTransparencyInterceptor(
     logListService,
     logListDataSource,
     policy,
-    diskCache
+    diskCache,
+    logger
 ) {
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
@@ -52,7 +52,8 @@ internal class CertificateTransparencyTrustManager(
     logListService = logListService,
     logListDataSource = logListDataSource,
     policy = policy,
-    diskCache = diskCache
+    diskCache = diskCache,
+    logger = logger
 ) {
 
     private val checkServerTrustedMethod: Method? = try {


### PR DESCRIPTION
Surround runBlocking block with try/catch to avoid potential InterruptedException when network request is sent using RxJava approach and Rx subscription is cleared